### PR TITLE
fixing Android/build.gradle for Eclipse import

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,7 +66,7 @@ eclipse {
     }
 
     classpath {
-        plusConfigurations += project.configurations.compile        
+        plusConfigurations += [ project.configurations.compile ]     
         containers 'com.android.ide.eclipse.adt.ANDROID_FRAMEWORK', 'com.android.ide.eclipse.adt.LIBRARIES'       
     }
 


### PR DESCRIPTION
Without this change import in Eclipse will fail.
